### PR TITLE
Remove print call in plotting function

### DIFF
--- a/R/plot_indicator.R
+++ b/R/plot_indicator.R
@@ -28,13 +28,13 @@
 #' @examples
 #' \dontrun{
 #' # Plot V-Dem indicators liberal democracy and egalitarian democracy
-#' for Sweden and Germany between 1912 and 2000.
+#' # for Sweden and Germany between 1912 and 2000.
 #'
 #'  plot_indicator(indicator=c( "v2x_egaldem", "v2x_libdem"), countries = c("Germany", "Sweden"),
 #'                      min_year = 1912, max_year = 2000)
 #'
 #' # Plot the global averages of V-Dem indicators electoral and egalitarian democracy
-#'  between 1940 and 2010.
+#' # between 1940 and 2010.
 #'
 #'  plot_indicator(indicator=c("v2x_polyarchy", "v2x_egaldem"),
 #'                      min_year = 1940, max_year = 2010)
@@ -55,14 +55,14 @@ year <- country_name <- value <- mean_indicator <- vdem <- name <- type <- codel
       dplyr::summarize(mean_indicator = mean(value, na.rm = T)) %>%
       tidyr::drop_na()
 
-    print(ggplot2::ggplot(data,
-                          aes(x = year, y = mean_indicator, fill = indicator, shape = indicator)) +
-            geom_line() + geom_point() + xlab("") +
-            ylab(ifelse(length(indicator) == 1, indicator, "")) +
-            scale_x_continuous(breaks = seq(round(min_year / 10) * 10, round(max_year / 10) * 10, 10)) +
-            scale_shape_manual("Indicator", values = rep(0:length(indicator)), labels = indicator) +
-            scale_fill_manual("Indicator", values = rep(0:length(indicator)), labels = indicator) +
-            theme_bw())
+    ggplot2::ggplot(data,
+                    aes(x = year, y = mean_indicator, fill = indicator, shape = indicator)) +
+        geom_line() + geom_point() + xlab("") +
+        ylab(ifelse(length(indicator) == 1, indicator, "")) +
+        scale_x_continuous(breaks = seq(round(min_year / 10) * 10, round(max_year / 10) * 10, 10)) +
+        scale_shape_manual("Indicator", values = rep(0:length(indicator)), labels = indicator) +
+        scale_fill_manual("Indicator", values = rep(0:length(indicator)), labels = indicator) +
+        theme_bw()
   }
   # If uncertainty is turned off or indicators do not have uncertainty estimates plot those variables
   else if (isFALSE(uncertainty) == T | length(intersect(colnames(vdem), paste(indicator, "_codehigh", sep = ""))) < 1) {
@@ -74,15 +74,15 @@ year <- country_name <- value <- mean_indicator <- vdem <- name <- type <- codel
       tidyr::pivot_longer(starts_with("indicator"), names_to = "indicator", values_to = "value") %>%
       tidyr::drop_na()
 
-    print(ggplot2::ggplot(data,
-                          aes(x = year, y = value, shape = indicator, color = country_name)) +
-            geom_line(alpha = 0.80) + geom_point() + xlab("") +
-            ylab("") +
-            scale_x_continuous(breaks = seq(round(min_year / 10) * 10, round(max_year / 10) * 10, 10)) +
-            scale_color_manual(values = colour_palette[seq_len(length(countries))], name = "Country",
-                               labels = sort(countries)) +
-            scale_shape_manual(values = rep(0:length(indicator)), labels = indicator, name = "Indicator") +
-            theme_bw())
+    ggplot2::ggplot(data,
+                    aes(x = year, y = value, shape = indicator, color = country_name)) +
+        geom_line(alpha = 0.80) + geom_point() + xlab("") +
+        ylab("") +
+        scale_x_continuous(breaks = seq(round(min_year / 10) * 10, round(max_year / 10) * 10, 10)) +
+        scale_color_manual(values = colour_palette[seq_len(length(countries))], name = "Country",
+                           labels = sort(countries)) +
+        scale_shape_manual(values = rep(0:length(indicator)), labels = indicator, name = "Indicator") +
+        theme_bw()
   }
   # Plot selected variables for selected countries including uncertainty estimates
   else {
@@ -103,19 +103,19 @@ year <- country_name <- value <- mean_indicator <- vdem <- name <- type <- codel
                          id_cols = c(country_name, year, indicator)) %>%
       tidyr::drop_na()
 
-    print(ggplot2::ggplot(data,
-                          aes(x = year, y = value, shape = indicator, color = country_name)) +
-            geom_line(alpha = .80) + geom_point() +
-            geom_ribbon(aes(x = year, ymin = codelow,
-                            ymax = codehigh,
-                            linetype = NA, fill = country_name), alpha = .25) + xlab("") +
-            xlab("") + ylab("") +
-            scale_x_continuous(breaks = seq(round(min_year / 10) * 10, round(max_year / 10) * 10, 10)) +
-            scale_color_manual(values = colour_palette[seq_len(length(countries))], name = "Country",
-                               labels = sort(countries)) +
-            scale_fill_manual(values = colour_palette[seq_len(length(countries))], name = "Country",
-                              labels = sort(countries)) +
-            scale_shape_manual(values = rep(0:length(indicator)), labels = indicator, name = "Indicator") +
-            theme_bw())
+    ggplot2::ggplot(data,
+                    aes(x = year, y = value, shape = indicator, color = country_name)) +
+        geom_line(alpha = .80) + geom_point() +
+        geom_ribbon(aes(x = year, ymin = codelow,
+                        ymax = codehigh,
+                        linetype = NA, fill = country_name), alpha = .25) + xlab("") +
+        xlab("") + ylab("") +
+        scale_x_continuous(breaks = seq(round(min_year / 10) * 10, round(max_year / 10) * 10, 10)) +
+        scale_color_manual(values = colour_palette[seq_len(length(countries))], name = "Country",
+                           labels = sort(countries)) +
+        scale_fill_manual(values = colour_palette[seq_len(length(countries))], name = "Country",
+                          labels = sort(countries)) +
+        scale_shape_manual(values = rep(0:length(indicator)), labels = indicator, name = "Indicator") +
+        theme_bw()
   }
 }


### PR DESCRIPTION
I don't know if the `print` call is intended behavior, but it's usually nice to return the raw ggplot object so that it can be further modified by the end user if desired. 