### PR TITLE
Bump minimum R version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,15 +3,19 @@ Type: Package
 Title: Provides most recent V-Dem data and some additional features
 Version: 0.1.0
 Authors@R: c(person("Seraphine", "Maerz", email = "seraphine.maerz@v-dem.net", role = c("aut", "cre")),
-              person("Amanda", "Edgell", email = "amanda.edgell@v-dem.net", role = c("aut")),
-              person("Joshua", "Krusell", email = "js.shirin@gmail.com", role = c("aut")),
-              person("Laura", "Maxwell", email = "laura.maxwell@v-dem.net", role = c("aut")),
-	            person("Sebastian", "Hellmeier", email = "sebastian.hellmeier@v-dem.net", role = c("aut")),
-	            person("Nina", "Ilchenko", email = "nina.ilchenko@v-dem.net", role = c("aut")))
-Maintainer: The package maintainer <seraphine.maerz@v-dem.net>
-Description: This package contains the most recent full V-Dem data set plus external variables (see here: https://www.v-dem.net/en/data/data-version-10/) and offers some additional functions to work with vdem data.
+             person("Amanda", "Edgell", email = "amanda.edgell@v-dem.net", role = c("aut")),
+             person("Joshua", "Krusell", email = "js.shirin@gmail.com", role = c("aut")),
+             person("Laura", "Maxwell", email = "laura.maxwell@v-dem.net", role = c("aut")),
+             person("Sebastian", "Hellmeier", email = "sebastian.hellmeier@v-dem.net", role = c("aut")),
+             person("Nina", "Ilchenko", email = "nina.ilchenko@v-dem.net", role = c("aut")))
+Maintainer: Seraphine Maerz <seraphine.maerz@v-dem.net>
+Description: This package contains the most recent full V-Dem data set
+             plus external variables (see here:
+             https://www.v-dem.net/en/data/data-version-10/) and
+             offers some additional functions to work with vdem data.
+Depends: R (>= 3.5.0)
 Imports:
-  dplyr, 
+  dplyr,
   tidyr,
   Rcpp,
   ggplot2,


### PR DESCRIPTION
The package is currently the latest R serialization format for the vdem and codebook data which is only compatible with R >= 3.5.0