### PR TITLE
Revert NA checks in cpp functions

### DIFF
--- a/src/find_seqs_aut.cpp
+++ b/src/find_seqs_aut.cpp
@@ -30,11 +30,6 @@ NumericVector find_seqs_aut(NumericVector v,
   if (v.size() != r.size())
     stop("Mismatched vector lengths");
 
-  for (size_t i = 0; i < v.size(); i++) {
-    if (NumericVector::is_na(v[i]) != NumericVector::is_na(r[i]))
-      stop("Mismatched NAs in vectors");
-  }
-
   if (start_incl > 0 || year_turn < 0 || cum_turn < 0)
     stop("start_incl must be negative and year_turn and cum_turn positive");
 

--- a/src/find_seqs_dem.cpp
+++ b/src/find_seqs_dem.cpp
@@ -29,11 +29,6 @@ NumericVector find_seqs_dem(NumericVector v,
   if (v.size() != r.size())
     stop("Mismatched vector lengths");
 
-  for (size_t i = 0; i < v.size(); i++) {
-    if (NumericVector::is_na(v[i]) != NumericVector::is_na(r[i]))
-      stop("Mismatched NAs in vectors");
-  }
-
   if (start_incl < 0 || year_turn > 0 || cum_turn > 0)
     stop("start_incl must be positive and year_turn and cum_turn negative");
 

--- a/tests/testthat/test-find_seqs_aut.R
+++ b/tests/testthat/test-find_seqs_aut.R
@@ -12,8 +12,6 @@
 
 test_that("Invalid function arguments", {
     expect_error(find_seqs_aut(c(1, 2), 1))
-    expect_error(find_seqs_aut(c(1, 2), c(1, NA)))
-    expect_error(find_seqs_aut(c(1, NA), c(1, 2)))
     expect_error(find_seqs_aut(1, 1, start_incl = 1))
     expect_error(find_seqs_aut(1, 1, year_turn = -1))
     expect_error(find_seqs_aut(1, 1, cum_turn = -1))

--- a/tests/testthat/test-find_seqs_dem.R
+++ b/tests/testthat/test-find_seqs_dem.R
@@ -12,8 +12,6 @@
 
 test_that("Invalid function arguments", {
     expect_error(find_seqs_dem(c(1, 2), 1))
-    expect_error(find_seqs_dem(c(1, 2), c(1, NA)))
-    expect_error(find_seqs_dem(c(1, NA), c(1, 2)))
     expect_error(find_seqs_dem(1, 1, start_incl = -1))
     expect_error(find_seqs_dem(1, 1, year_turn = 1))
     expect_error(find_seqs_dem(1, 1, cum_turn = 1))


### PR DESCRIPTION
There's mismatches between v2x_polyarchy and v2x_regime in terms of NA.
To ensure the code runs as is right now, revert the previous changes.
Eventually this will have to be revisited since this results in
undefined behaviour according to the rules laid out by the algorithm.